### PR TITLE
Add OpenAI summarization helper and integrate in chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ export default tseslint.config([
 ])
 ```
 
+## Environment variables
+
+Set the following variables in a `.env` file so the application can talk to the OpenAI API:
+
+```bash
+VITE_OPENAI_API_KEY=your-api-key
+VITE_OPENAI_ENDPOINT=https://api.openai.com/v1/chat/completions
+```
+
+## Usage
+
+Upload a CSV on the **Upload** page and proceed to **Chat**. Sending a message will
+request a short summary of the uploaded data from the OpenAI API and display it
+in the assistant chat.
+
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -1,16 +1,31 @@
 import { useState } from "react";
 import StepNavigation from "../components/StepNavigation";
+import { useApp } from "../context/AppContext";
+import { summarizeData } from "../utils/openai";
 
 export default function Chat() {
-  const [messages, setMessages] = useState<{role: string, text: string}[]>([
-    { role: "assistant", text: "Hi! How can I help you with your analysis?" }
+  const { csvPreview } = useApp();
+  const [messages, setMessages] = useState<{ role: string; text: string }[]>([
+    { role: "assistant", text: "Hi! How can I help you with your analysis?" },
   ]);
   const [input, setInput] = useState("");
 
-  function sendMessage() {
-    if (input.trim()) {
-      setMessages(m => [...m, { role: "user", text: input }]);
-      setInput("");
+  async function sendMessage() {
+    if (!input.trim()) return;
+    const userMsg = input;
+    setMessages(m => [...m, { role: "user", text: userMsg }]);
+    setInput("");
+
+    if (csvPreview) {
+      try {
+        const summary = await summarizeData(csvPreview);
+        setMessages(m => [...m, { role: "assistant", text: summary }]);
+      } catch {
+        setMessages(m => [
+          ...m,
+          { role: "assistant", text: "Failed to summarise data." },
+        ]);
+      }
     }
   }
 

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -13,8 +13,8 @@ export default function Upload() {
     setCsvPreview(null);
     if (file) {
       Papa.parse(file, {
-        complete: (result: any) => {
-          const data = result.data as string[][];
+        complete: (result: unknown) => {
+          const data = (result as { data: string[][] }).data;
           setCsvPreview(data);
         },
         error: () => setCsvPreview(null),

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -1,0 +1,31 @@
+export async function summarizeData(data: string[][]): Promise<string> {
+  const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+  const endpoint = import.meta.env.VITE_OPENAI_ENDPOINT;
+
+  if (!apiKey || !endpoint) {
+    throw new Error("OpenAI environment variables are missing");
+  }
+
+  const prompt = `Provide a short summary of the following CSV data:\n${data.map(row => row.join(',')).join('\n')}`;
+
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'user', content: prompt },
+      ],
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch summary');
+  }
+
+  const json = await res.json();
+  return json.choices?.[0]?.message?.content?.trim() ?? '';
+}


### PR DESCRIPTION
## Summary
- add `summarizeData` helper for calling OpenAI API
- integrate summary generation in Chat page
- fix lint error in `Upload` page
- document required environment variables and usage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ce9167c64832da770174dcac69989