### PR TITLE
Add .env.example and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for ara-react
+VITE_OPENAI_API_KEY=your-api-key
+VITE_OPENAI_ENDPOINT=https://api.openai.com/v1/chat/completions

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ export default tseslint.config([
 
 ## Environment variables
 
-Set the following variables in a `.env` file so the application can talk to the OpenAI API:
+Copy `.env.example` to `.env` and fill in your OpenAI credentials so the application can talk to the API:
 
 ```bash
 VITE_OPENAI_API_KEY=your-api-key


### PR DESCRIPTION
## Summary
- add an `.env.example` with placeholder keys
- instruct users in `README.md` to copy the example to `.env`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ceacd946c832d8ee59a7bf2f7214f