### PR TITLE
Add data summary generation and display

### DIFF
--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -2,7 +2,7 @@ import { useApp } from "../context/AppContext";
 import StepNavigation from "../components/StepNavigation";
 
 export default function Plan() {
-  const { uploadedFile } = useApp();
+  const { uploadedFile, summary } = useApp();
 
   return (
     
@@ -19,6 +19,11 @@ export default function Plan() {
         </div>
       ) : (
         <div className="mb-4 text-gray-400">No dataset uploaded yet.</div>
+      )}
+      {summary && (
+        <div className="mb-4 p-3 rounded bg-yellow-50 text-yellow-800 shadow-inner">
+          <strong>Data summary:</strong> {summary}
+        </div>
       )}
       {/* Your plan content here */}
       <StepNavigation prev={{ to: "/upload" }} next={{ to: "/chat" }} />

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -8,21 +8,25 @@ export default function Upload() {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const { uploadedFile, setUploadedFile, csvPreview, setCsvPreview, setSummary } = useApp();
 
+  async function generateSummary(data: string[][]) {
+    try {
+      const summary = await summarizeData(data);
+      setSummary(summary);
+    } catch {
+      setSummary(null);
+    }
+  }
+
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0] ?? null;
     setUploadedFile(file);
     setCsvPreview(null);
     if (file) {
       Papa.parse(file, {
-        complete: async (result: unknown) => {
+        complete: (result: unknown) => {
           const data = (result as { data: string[][] }).data;
           setCsvPreview(data);
-          try {
-            const summary = await summarizeData(data);
-            setSummary(summary);
-          } catch {
-            setSummary(null);
-          }
+          generateSummary(data);
         },
         error: () => {
           setCsvPreview(null);


### PR DESCRIPTION
## Summary
- generate dataset summaries after CSV parsing
- show the data summary on the Plan page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686fb2bdaa6c832db791a5827f3b83cc