### PR TITLE
Update server for code interpreter

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -33,7 +33,8 @@ app.post('/api/summarize', async (req, res) => {
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
+        model: 'gpt-4o',
+        tools: [{ type: 'code_interpreter' }],
         messages: [{ role: 'user', content: prompt }],
       }),
     });


### PR DESCRIPTION
## Summary
- use `gpt-4o` in the backend
- enable `code_interpreter` tool

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686fb86dfe18832d85942c79cf29029d