### PR TITLE
Add spinner state and component

### DIFF
--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,7 @@
+export default function Spinner({ className = "" }: { className?: string }) {
+  return (
+    <div
+      className={`animate-spin h-5 w-5 rounded-full border-2 border-t-transparent border-current ${className}`}
+    />
+  );
+}

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import StepNavigation from "../components/StepNavigation";
+import Spinner from "../components/Spinner";
 import { useApp } from "../context/AppContext";
 import { summarizeData } from "../utils/openai";
 
@@ -67,10 +68,10 @@ export default function Chat() {
         />
         <button
           onClick={sendMessage}
-          className="rounded px-4 bg-blue-600 text-white font-semibold disabled:opacity-50"
+          className="rounded px-4 bg-blue-600 text-white font-semibold disabled:opacity-50 flex items-center justify-center"
           disabled={loading}
         >
-          {loading ? "Summarizing…" : "Send"}
+          {loading ? <Spinner className="text-white" /> : "Send"}
         </button>
       </div>
       <StepNavigation prev={{ to: "/plan" }} next={{ to: "/report" }} />

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -1,19 +1,24 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useApp } from "../context/AppContext";
 import StepNavigation from "../components/StepNavigation";
+import Spinner from "../components/Spinner";
 import Papa from "papaparse";
 import { summarizeData } from "../utils/openai";
 
 export default function Upload() {
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const [loading, setLoading] = useState(false);
   const { uploadedFile, setUploadedFile, csvPreview, setCsvPreview, setSummary } = useApp();
 
   async function generateSummary(data: string[][]) {
+    setLoading(true);
     try {
       const summary = await summarizeData(data);
       setSummary(summary);
     } catch {
       setSummary(null);
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -78,6 +83,11 @@ export default function Upload() {
               </tbody>
             </table>
           </div>
+        </div>
+      )}
+      {loading && (
+        <div className="flex justify-center my-4">
+          <Spinner />
         </div>
       )}
       <StepNavigation next={{ to: "/plan" }} />


### PR DESCRIPTION
## Summary
- add a reusable `Spinner` component
- display spinner while CSV summary is being generated
- show spinner on Chat page during summarization

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686fb87b966c832db9851c44e20304aa